### PR TITLE
Add new Getting Started page to promote trials

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -41,6 +41,7 @@ While all content is searchable, the site is organized into the following sectio
    StartUpGuides/aviatrix-cloud-controller-startup-guide
    StartUpGuides/azure-aviatrix-cloud-controller-startup-guide
    StartUpGuides/google-aviatrix-cloud-controller-startup-guide
+   StartUpGuides/start-a-free-trial
    StartUpGuides/CloudN-Startup-Guide
    StartUpGuides/appendix-CloudN-Startup-Guide
    StartUpGuides/aviatrix-china-controller-startup-guide


### PR DESCRIPTION
I've added a pointer above to a suggested new page that will make our trials more visible.  Here is the suggested content for the page. It comes from the already approved FAQ for AHS on the website.

<h1>Start a Free Trial</h1>
<p>You have two highly secure ways to leverage the Aviatrix Controller: your cloud or ours. The software-defined Aviatrix Gateways are still deployed in your VPCs via that Controller.</p>
<ul>
<li>By using the Hosted Service to access the Controller, it’s one less instance of infrastructure software that you have to maintain and manage. While you still retain all the control with the Hosted Service, Aviatrix can provide proactive assistance with software upgrades.</li>
<li>For more control, you can deploy the Aviatrix AMI Software version in your own VPCs instead.</li>
</ul>
<p>Both versions are available with 14-day free trials and billed monthly thereafter. The functionality and pricing model is the same:</p>
<ul>
<li>Hosted Service Trial: <a href="https://www.aviatrix.com/trial/" target="_blank">Sign up now</a>.</li>
<li>Aviatrix AMI Software: Install using the <a href="https://docs.aviatrix.com/StartUpGuides/aviatrix-cloud-controller-startup-guide.html" target="_blank">AWS Startup Guide</a>, and choose the "Utility AMI Aviatrix Secure Networking Platform - Custom AMI" option.</li>
</ul>