### PR TITLE
Changes to make the statement more general

### DIFF
--- a/Solutions/gateway_ha.rst
+++ b/Solutions/gateway_ha.rst
@@ -25,7 +25,7 @@ The Aviatrix Controller monitors your cloud networking deployment, detects probl
 
 These options give you the flexibility to select the one that meets your requirements for recovery time.  For production environments, a quicker recovery time is typically very important.  But, for development environments, a longer delay is acceptable.  With Aviatrix HA, you can mix and match these options in your deployment to meet your needs.
 
-As the recovery time decreases, there may be additional costs to consider.  `Single AZ` has no additional costs.  `Backup Gateway` will incur additional EC2 instance charges (for the additional gateway provisioned).  `Backup Gateway and Tunnel(s)` will incur additional EC2 costs and additional tunnel costs.
+As the recovery time decreases, there may be additional costs to consider.  `Single AZ` has no additional costs.  `Backup Gateway` will incur additional instance charges (for the additional gateway provisioned).  `Backup Gateway and Tunnel(s)` will also incur additional costs.
 
 How is a Gateway or Tunnel Determined to be Down?
 -------------------------------------------------


### PR DESCRIPTION
The paragraph mentioning the recovery times is general (meant for all cloud types) but it uses AWS terms. Removing them to make it sound right.