### PR TITLE
Add Port 943 Requirement to OpenVPN with ELB

### DIFF
--- a/Support/support_center_openvpn_gateway.rst
+++ b/Support/support_center_openvpn_gateway.rst
@@ -311,6 +311,7 @@ If you have deployed a TCP based Aviatrix OpenVPN Gateways behind an AWS Elastic
 
   * IP Address: AWS Load Balancers' public IP
   * Port: 443
+  * Port: 943
 
 If you have deployed a UDP based OpenVPN Gateway (i.e. without an ELB enabled)
 


### PR DESCRIPTION
This is mentioned here: https://docs.aviatrix.com/HowTos/Troubleshooting_Diagnostics_Result.html#diagnostic-result but for the sake of consistency, we should add it to the required ports too.