### PR TITLE
Link to connected-transit is broken

### DIFF
--- a/HowTos/transitvpc_faq.rst
+++ b/HowTos/transitvpc_faq.rst
@@ -263,7 +263,7 @@ Before you can summarize Spoke VPC CIDRs, you must make sure Spoke gateways all 
 How to build Spoke to Spoke connectivity via Transit?
 ------------------------------------------------------
 
-Starting from release 3.5, Transit network supports Connected mode. https://docs.aviatrix.com/HowTos/transitvpc_designs.html#connected-transit-design_ where Spoke to Spoke connectivity is built automatically.
+Starting from release 3.5, Transit network supports `Connected mode. https://docs.aviatrix.com/HowTos/transitvpc_designs.html#connected-transit-design_` where Spoke to Spoke connectivity is built automatically.
 
 How do a Spoke gateway and VPC private DNS work together?
 ----------------------------------------------------------

--- a/HowTos/transitvpc_faq.rst
+++ b/HowTos/transitvpc_faq.rst
@@ -263,7 +263,7 @@ Before you can summarize Spoke VPC CIDRs, you must make sure Spoke gateways all 
 How to build Spoke to Spoke connectivity via Transit?
 ------------------------------------------------------
 
-Starting from release 3.5, Transit network supports `Connected mode. <https://docs.aviatrix.com/HowTos/site2cloud.html#connected-transit>`_ where Spoke to Spoke connectivity is built automatically.
+Starting from release 3.5, Transit network supports Connected mode. https://docs.aviatrix.com/HowTos/transitvpc_designs.html#connected-transit-design_ where Spoke to Spoke connectivity is built automatically.
 
 How do a Spoke gateway and VPC private DNS work together?
 ----------------------------------------------------------


### PR DESCRIPTION
link to connected-transit seems to point to site2cloud page. updating the link to point to our connected transit design page.