### PR TITLE
Removing unnecessary step

### DIFF
--- a/HowTos/config_paloaltoVM.rst
+++ b/HowTos/config_paloaltoVM.rst
@@ -123,18 +123,6 @@ Policies > NAT > Click "Add" > Click General tab, give it a name > Click Origina
 
  |nat_translated_packet|
 
-10. Configure Default Virtual Router
-------------------------------
-Under Network > Virtual Routers > Static Routes > Click on "Default"
-
-Destination : 0.0.0.0/0
-
-Interface : ethernet1/1
-
-Next Hop : None
-
-Click "Commit"
-
 11. Setup API access 
 ----------------------
 


### PR DESCRIPTION
When we enable egress functionalities, the controller automatically installs the default route in the PAN instance, asking users to configure this manually in this document is confusing and causes paloalto configuration commit errors.