### PR TITLE
Line 88 pointint to the wrong URL

### DIFF
--- a/HowTos/transit_advanced.rst
+++ b/HowTos/transit_advanced.rst
@@ -85,7 +85,7 @@ This option is to provide the flexibility on Aviatrix Transit Gateways to connec
 
 The use case is a deployment scenario where on-prem device such as firewall does not support asymmetric routing on two tunnels. When Active-Standby mode is enabled, it applies to both BGP and Static Remote Route Based External Device Connections and for each connection, only one tunnel is active in forwarding traffic at any given time. 
 
-This feature can only be applied to non HA remote device in `Multi-cloud transit Step 3 <https://docs.aviatrix.com/HowTos/transitvpc_workflow.html#external-device>`_.
+This feature can only be applied to non HA remote device in `Multi-cloud transit Step 3 <https://docs.aviatrix.com/HowTos/transitvpc_workflow.html#external-device>`_. <--// This is wrong //-->
 
 Click the Slide Bar to enable Active-Standby mode. 
 


### PR DESCRIPTION
"This feature can only be applied to non HA remote device in Multi-cloud transit Step 3." is pointing to the wrong URL.