### PR TITLE
Update controller_backup.rst

### DIFF
--- a/HowTos/controller_backup.rst
+++ b/HowTos/controller_backup.rst
@@ -85,6 +85,8 @@ Once you are past the initial configuration steps:
 
 |imageRestoreAWS|
 
+  If Aviatrix Managed CloudN exists in the backup controller, after the restore operation on the new controller, you will need to go to the Aviatrix Managed CloudN UI and follow the steps of 2.2 and 2.5 by entering the new FQDN or IP of the new controller to complete the restore.  You will be required to repeat 2.5 on other Aviatrix Managed CloudN if you have more than one Managed CloudN device.
+  
 
 How to backup configuration with AWS encrypted storage
 ------------------------------------------------------


### PR DESCRIPTION
Add a note to the end of restoring a new controller for Aviatrix Managed CloudN devices.

If Aviatrix Managed CloudN exists in the backup controller, after the restore operation on the new controller, you will need to go to the Aviatrix Managed CloudN UI and follow the steps of 2.2 and 2.5 by entering the new FQDN or IP of the new controller to complete the restore. You will be required to repeat 2.5 on other Aviatrix Managed CloudN if you have more than one Managed CloudN device.