### PR TITLE
Update Fail Close feature description

### DIFF
--- a/HowTos/firewall_advanced.rst
+++ b/HowTos/firewall_advanced.rst
@@ -40,7 +40,7 @@ can pass through the FireNet gateways without having any attached firewalls, mak
 as a lookback interface. This is useful as it allows you  to isolate and test network connectivity 
 during troubleshooting.  
 
-When Fail Close is disabled, FireNet gateway drops all traffic when there are no firewalls 
+When Fail Close is enabled, FireNet gateway drops all traffic when there are no firewalls 
 attached to the FireNet gateways. 
 
 


### PR DESCRIPTION
The description that's live currently reads "When fail close is disabled" for both the enabled and disabled feature functionality. This PR just fixes this to describe the correct behavior for that feature.