### PR TITLE
Fix typo in VPN client guide.

### DIFF
--- a/Downloads/vpnclientguide.rst
+++ b/Downloads/vpnclientguide.rst
@@ -201,7 +201,7 @@ Mac |mac|
 
 
 ***********************
-Advanced Setttings Page
+Advanced Settings Page
 ***********************
 
 |Settings|


### PR DESCRIPTION
Settings was mispelled.