### PR TITLE
Pin docutils to 0.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 sphinxcontrib-disqus
 ## use v1.5.5 of Sphinx to make disqus work correctly
 sphinx==1.5.5
+## pin docutils to 0.17 to work around https://github.com/sphinx-doc/sphinx/issues/9727
+docutils<0.18
 


### PR DESCRIPTION
Pin docutils to 0.17 to work around https://github.com/sphinx-doc/sphinx/issues/9727.