### PR TITLE
Re-ordering document, Vendor integration must happen *after* ethernet…

### DIFF
--- a/HowTos/config_PaloAltoAzure.rst
+++ b/HowTos/config_PaloAltoAzure.rst
@@ -52,17 +52,7 @@ eth2 (on subnet -dmz-firewall_lan)                               LAN or Trusted 
 
 Note that firewall instance eth2 is on the same subnet as FireNet gateway eth2 interface.
 
-2. Vendor Firewall Integration
----------------------------------
-
-This step automatically configures the RFC 1918 and non-RFC 1918 routes between Aviatrix Gateway and Vendor’s firewall instance in this case Palo Alto Networks VM-Series. This can also be done manually through Cloud Portal and/or Vendor’s Management tool.
-
-1.	Go to Firewall Network -> Vendor Integration -> Select Firewall, fill in the details of your Firewall instance.
-2.	Click Save, Show and Sync.
-
-|vendor_integration_example|
-
-3. Login to VM-Series
+2. Login to VM-Series
 ------------------------
 
 Go back to the Aviatrix Controller Console.
@@ -72,10 +62,10 @@ Login with Username "panadmin". Password is the password you set at the previous
 
 |avx-firewall-step7a_UI|
 
-4. Activate VM license
+3. Activate VM license
 ------------------------
 
-5. Dynamic updates
+4. Dynamic updates
 ------------------------
 
 Go to Device > Dynamic Updates > Click on "Check Now"
@@ -86,7 +76,7 @@ Go to Device > Dynamic Updates > Click on "Check Now"
 |pan_dynamic_updates|
 
 
-6. Configure VM-Series ethernet1/1 with WAN Zone
+5. Configure VM-Series ethernet1/1 with WAN Zone
 -------------------------------------------------
 
 Once logged in, click on the Network tab and you should see a list of ethernet interfaces. Click ethernet1/1 and
@@ -112,13 +102,22 @@ Continue,
 
 Click **Commit**. Once Commit is complete, you should see the Link State turn green at the Network page for ethernet1/1.
 
-7. Configure VM-Series ethernet1/2 with LAN Zone
+6. Configure VM-Series ethernet1/2 with LAN Zone
 ---------------------------------------------------
 
 Repeat Step 6 for ethernet1/2. Name the new zone LAN.
 
 Click **Commit**. Once Commit is complete, you should see the Link State turn green at the Network page for ethernet1/2.
 
+7. Vendor Firewall Integration
+---------------------------------
+
+This step automatically configures the RFC 1918 and non-RFC 1918 routes between Aviatrix Gateway and Vendor’s firewall instance in this case Palo Alto Networks VM-Series. This can also be done manually through Cloud Portal and/or Vendor’s Management tool.
+
+1.	Go to Firewall Network -> Vendor Integration -> Select Firewall, fill in the details of your Firewall instance.
+2.	Click Save, Show and Sync.
+
+|vendor_integration_example|
 
 8. Enable VM-Series Health Check Policy
 ----------------------------------------------


### PR DESCRIPTION
Before ethernet 1/2 assigned as 'default' virtual router, run Vendor integration will get you this screen:

![image](https://user-images.githubusercontent.com/93721751/141037861-463e1edd-b861-4742-9b1a-0942d8d9e415.png)

Hence must change the deployment order.
