### PR TITLE
Adding instructions and removing an obsolete section

### DIFF
--- a/HowTos/iam_policies.rst
+++ b/HowTos/iam_policies.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: How to update the Aviatrix AWS IAM policies
-  :keywords: account, aviatrix, AWS IAM role, IAM policies
+  :description: How to audit and update the Aviatrix AWS IAM policies
+  :keywords: account, aviatrix, AWS IAM role, IAM policies, update
 
 
 =================================
@@ -10,23 +10,21 @@ AWS IAM Policies
 The Aviatrix Controller in AWS is launched by `a CloudFormation script  <https://docs.aviatrix.com/StartUpGuides/aviatrix-cloud-controller-startup-guide.html>`_. 
 During the launch time, two IAM roles are created, aviatrix-role-ec2 and aviatrix-role-app. Two associated IAM policies are also created, `aviatrix-assume-role-policy <https://s3-us-west-2.amazonaws.com/aviatrix-download/iam_assume_role_policy.txt>`_ and `aviatrix-app-policy <https://s3-us-west-2.amazonaws.com/aviatrix-download/IAM_access_policy_for_CloudN.txt>`_.
 
-Automatically Updating IAM Policies
+Occasionally, you may need to update your AWS IAM policies to make sure you are using the most current version. This document shows you, an Aviatrix user with at least one AWS account, how to:
+* Audit and update your AWS IAM policies in the Aviatrix Controller.
+* Update your AWS IAM policies in your AWS Account.
+
+Auditing and Updating AWS IAM Policies in the Aviatrix Controller
 --------------------------------------
 
-Login to the Controller. Go to Accounts -> Access Accounts. Select an account and click the 3 dots skewer, click Update Policy. The latest IAM policy will be updated for this account. Repeat this step for all other accounts. 
+To audit and, if needed, update your AWS IAM policies in your Aviatrix Controller, log in to the Aviatrix Controller.
+#. On the left, click **Accounts** > **Access Accounts**.
+#. Select an AWS account and click **Audit** near to the top of the page. If this account needs an update, text under Account Audit at the top of the page reads "[Account Name] is not using the latest IAM policy."
+#. If the account is not using the latest IAM policy, click **Update Policy**. The latest IAM policy will be updated for this account.
+#. Repeat this step for all other AWS accounts.
 
-
-
-Updating IAM Policies
+Updating AWS IAM Policies in your AWS Account
 ---------------------
-
-This section describes how to update IAM policies manually. We recommend you to update automatically follow the instructions 
-in the previous section.
-
-These two roles and their associated policies allow the Controller to use AWS APIs to launch gateway instances, 
-create new route entries and build networks. 
-
-As more features are added by Aviatrix with each release, the IAM Access Policy may need to be updated to allow the Controller to launch new services. 
 
 .. note::
    Please note that both the Aviatrix Controllers and the Aviatrix Gateways need access to the IAM policies.
@@ -39,34 +37,15 @@ Updating the IAM policies with the latest one is done by replacing them. Follow 
 Steps
 ^^^^^
 
-#. Login to the account on the AWS Console
-#. At Services, go to **IAM**
-#. Click **Policies**
-#. Search for **aviatrix-app-policy**
-#. Click into the **aviatrix-app-policy**
-#. Click **Edit policy**
-#. Click **JSON**
+#. Log in to your account on the AWS Console.
+#. At Services, go to **IAM**.
+#. Click **Policies**.
+#. Search for **aviatrix-app-policy**.
+#. Click **aviatrix-app-policy**.
+#. Click **Edit policy**.
+#. Click **JSON**.
 #. Replace the entire text by the latest policy in `this link <https://s3-us-west-2.amazonaws.com/aviatrix-download/IAM_access_policy_for_CloudN.txt>`__
 #. Click **Review policy** to make sure there is no syntax error. 
-#. Click **Save changes** to apply the new aviatrix-app-policy.
-#. It may take a few minutes for the policy to take effect. 
-
-Check IAM Policy Status
--------------------------
-
-The `aviatrix-app-policy <https://s3-us-west-2.amazonaws.com/aviatrix-download/IAM_access_policy_for_CloudN.txt>`_ is updated sometimes for new services offered by Aviatrix. 
-
-You can view if your IAM policy needs to be 
-updated by going to Settings -> Advanced -> AWS IAM Policy Update. The Aviatrix Controller polls all
-AWS accounts upon each release to see if there is a new IAM policy available that you need to 
-update for your accounts. Note: if you do not run any new features, chances are you do not need to
-update the IAM policies. 
-
-You can also check individual account IAM policy status by selecting the account and clicking Check. 
-
-To update IAM policy, follow the instructions `here. <https://docs.aviatrix.com/HowTos/iam_policies.html#updating-iam-policies>`_
-
-
-
+#. Click **Save changes** to apply the new aviatrix-app-policy. It may take a few minutes for the policy to take effect.
 
 .. disqus::


### PR DESCRIPTION
Added instructions for auditing and updating your AWS IAM policies in the Aviatrix Controller itself. Reordered the sections to make more sense. I also removed the last section about checking your policies in AWS as that page no longer exists.