### PR TITLE
Changing instance size recommendation

### DIFF
--- a/HowTos/config_PFsense.rst
+++ b/HowTos/config_PFsense.rst
@@ -32,7 +32,7 @@ Deploy PFsense instance From AWS marketplace
 
 5	Now, choose your instance size. For this deployment we are going to need 2 network interfaces: management/egress and LAN. A 3-interface deployment is possible (separating management from egress) but not required, as it will also require a larger instance (due to the extra ENI)
 
-6	You can start with a t2.small for example. Although, for better network performance you might want to select a different instance type (m5, c5 or c5n) and a larger instance size. For more information on this subject we suggest starting at this AWS `document <https://aws.amazon.com/ec2/instance-types/ >`_ and the pfSense docs `page <https://docs.netgate.com/pfsense/en/latest/solutions/aws-vpn-appliance/launching-an-instance.html>`_ as well
+6	You can start with a t3.large for example, although for better network performance you might want to select a different instance type (m5, c5 or c5n) and a larger instance size. For more information on this subject we suggest starting at this AWS `document <https://aws.amazon.com/ec2/instance-types/ >`_ and the pfSense docs `page <https://docs.netgate.com/pfsense/en/latest/solutions/aws-vpn-appliance/launching-an-instance.html>`_ as well
 
 7	On the instance details page, the most relevant setting for any deployment is the subnet selection for the ENIs eth0 and eth1. If you have followed all the steps on the Firewall page, then your subnet selection should follow this logic:
 

--- a/StartUpGuides/aviatrix-cloud-controller-startup-guide.rst
+++ b/StartUpGuides/aviatrix-cloud-controller-startup-guide.rst
@@ -175,7 +175,7 @@ Change to the region  where you would like to install the Aviatrix Controller on
 2.6 Select instance size
 --------------------------
 
-Leave the `Controller Size` at `t2.large` and keep the `IAM role creation` at "New" unless you have already created the Aviatrix IAM roles.
+Set the `Controller Size` to `t3.large` and keep the `IAM role creation` at "New" unless you have already created the Aviatrix IAM roles.
 
 2.7 Click `Next`
 ------------------

--- a/StartUpGuides/aws_manual_startup_guide.rst
+++ b/StartUpGuides/aws_manual_startup_guide.rst
@@ -33,7 +33,7 @@ click at a region where you wish to launch the controller.
 
 Once you are at AWS EC2 console, follow the steps below:
 
-1.  Select the instance size “t2.large” of 8GB of memory, which is the minimum instance
+1.  Select the instance size “t3.large” of 8GB of memory, which is the minimum instance
     required.
 
 2.  Select the VPC where the controller will be launched.


### PR DESCRIPTION
Changing the AWS instance size recommendation from t2 to t3.large, since it will provide better performance at a lower cost