### PR TITLE
Doc scrub

### DIFF
--- a/StartUpGuides/aviatrix_operations.rst
+++ b/StartUpGuides/aviatrix_operations.rst
@@ -16,7 +16,7 @@ This document summarizes 10 operation services provided by Aviatrix Solutions.
 
  - **Simplicity** Point-and-Click work flow based instructions are designed for each use case and are easy to follow. Network CCIE are not required to deploy and manage the network. 
  - **Multi Accounts** Single pane of glass to manage all your cloud accounts for networking and networking security. 
- - **Multi Cloud** Single pane of glass to manage all your public cloud deployment for networking and networking security.
+ - **Multi-Cloud** Single pane of glass to manage all your public cloud deployment for networking and networking security.
  - **RBAC** Role Based Access Control allows you to manage multi accounts with fine grain access control for large organizations.
  - **Hitless Software Upgrade** Aviatrix software upgrades do not require the Controller nor gateway to reboot. The upgrade process takes a few minutes and does not cause any network downtime or packet loss. 
  - **Technical Documentation** In product links to well documented and agile publishing technical documentation site. 
@@ -26,11 +26,11 @@ This document summarizes 10 operation services provided by Aviatrix Solutions.
 
 
 2. Automation
-----------------
+---------------------
 
  - **API** All functions support API.
  - **Terraform** Aviatrix provides its own Terraform Provider for Aviatrix created resources.  
- - **Cloud Formation** Aviatrix provides Cloud Formation Scripts for AWS Controller launch and multi account creation. 
+ - **Cloud Formation** Aviatrix provides Cloud Formation Scripts for AWS Controller launch and multi-account creation. 
  - **Examples** Terraform examples are presented for various use cases.
 
 3. Visibility
@@ -40,8 +40,8 @@ This document summarizes 10 operation services provided by Aviatrix Solutions.
  - **Traffic Metrics** All Controller and gateway network traffic metrics are logged and displayed in time series.
  - **User Activities** Active VPN users and where they connect from is displayed. VPN user session history is logged and displayed.
  - **AWS Transit Gateway (TGW) Orchestrator View** A graphical view that displays what Security Domain and Connection Policies that have been configured. You can find for a given VPC, what other VPCs connect to it. 
- - **AWS Transit Gateway (TGW) Orchestrator List** Multi panel tables list, in real time, the Spoke VPC route table and TGW route table. 
- - **Egress FQDN Discovery** When this mode is enabled, Aviatrix gateway monitors all egress bound HTTP/HTTPS traffic, discovers the destination domain names and generates a report. This provides you the visibility of what APIs calls your EC2 applications are making. You can then use this visibility and turn it into FQDN filter policies.  
+ - **AWS Transit Gateway (TGW) Orchestrator List** Multi-panel tables list, in real time, the Spoke VPC route table and TGW route table. 
+ - **Egress FQDN Discovery** When this mode is enabled, Aviatrix gateway monitors all egress-bound HTTP/HTTPS traffic, discovers the destination domain names and generates a report. This provides you the visibility of what APIs calls your virtual machine (EC2/Azure Virtual Machine/GCE) applications are making. You can then use this visibility and turn it into FQDN filter policies.  
 
 
 4. Monitoring
@@ -55,7 +55,7 @@ This document summarizes 10 operation services provided by Aviatrix Solutions.
  - **Account Audit** The Controller periodically audits all access accounts it manages to make sure there is no accidental deletion of IAM roles and policies. When the Controller detects errors, it logs the event and sends an email alert to the admin user and the Aviatrix support team. 
  - **Gateway Disk/Memory Monitor** When Aviatrix gateway disk/memory reaches 95%, the Controller logs the event and sends an email alert to the admin user and the Aviatrix support team.
  - **VPC Tracker** Instead of using an Excel sheet, use this tool to keep track of all your network CIDRs and prevent duplicate network address ranges. 
- - **Alert Bell** Controller monitors the route table black hole, stops the instance, etc and displays a warning on the alert bell. 
+ - **Alert Bell** Controller monitors the route table black hole, stops the instance, etc. and displays a warning on the alert bell. 
 
 5. Logging
 -------------
@@ -72,8 +72,9 @@ The Controller and gateways can export logged data to the following services:
 
 
 6. Troubleshooting
----------------------
- - **Flightpath** Single pane of glass that displays information on Security Groups, VPC route entries, Network ACL and TGW Route tables in a side by side presentation for both source and destination. In addition, expert diagnostics identify the faulty setup in these resources. 
+--------------------------
+
+ - **Flightpath** Single pane of glass that displays information on Security Groups, VPC/VNet route entries, Network ACL, and TGW/Azure Virtual WAN/Cloude Router/Dynamic Routing Gateway Route tables in a side-by-side presentation for both source and destination. In addition, expert diagnostics identify the faulty setup in these resources. 
  - **Trace Route & Trace Path** Use this tool to help identify the route path. 
  - **Packet Capture** Capture packets on any gateway and download the resulting PCAP file for analysis on Wireshark.
  - **Network Validation** This tool can be used to test end to end connectivity. Instead of going to the cloud provider console to launch instances, this tool automatically launches two instances and tests the connectivity for you.  
@@ -83,13 +84,13 @@ The Controller and gateways can export logged data to the following services:
 7. High Availability
 ----------------------
 
- - **Controller Backup/Restore** All configurations are backed up to S3 daily and can be restored to a new Controller in the event that the existing Controller becomes unavailable. 
- - **Controller HA** You can deploy an auto scaling group of 1 that lets AWS CloudWatch monitor the Controller health. In the event that the existing Controller becomes unavailable it triggers an AWS Lambda function to launch a new Controller and restore its configurations. 
+ - **Controller Backup/Restore** All configurations are backed up to data storage solutions (S3 buckets/Azure Blob Storage/Google Cloud Storage/Object Storage Service) daily and can be restored to a new Controller in the event that the existing Controller becomes unavailable. 
+ - **Controller HA** You can deploy an auto scaling group of 1 that lets AWS CloudWatch monitor the Controller health. In the event that the existing Controller becomes unavailable, it triggers an AWS Lambda function to launch a new Controller and restore its configurations. 
  - **Active/Active Gateways** Aviatrix Gateways can be deployed Active/Active in multi-AZ and forward traffic with ECMP. 
 
 
 8. Compliance
---------------
+------------------------
 
  - **FIPS 140-2 Certificate** Aviatrix has achieved FIPS 140-2 compliance with certificate `#3475 <https://csrc.nist.gov/Projects/cryptographic-module-validation-program/Certificate/3475>`_.
  - **Security Patch** Any impacting vulnerability issues are immediately addressed by applying "Hot Fix".
@@ -97,18 +98,18 @@ The Controller and gateways can export logged data to the following services:
  - **LDAP** Supports LDAP authentication to login to the Controller. 
  
 9. Software and Technical Support
-------------------------------------
+---------------------------------------------
 
  - `Aviatrix Support Portal <https://support.aviatrix.com>`_ Technical problem? Have no fear. Aviatrix's most capable networking engineers are ready to help you troubleshoot issues large and small and most of them are not even related to Aviatrix solutions. Aviatrix offers 24/7 support for Platinum customers.
  - **Fast Release Cycle** New software releases become available every 6 - 8 weeks. A new software release automatically generates notification email to the Controller admin team.
  - **Hot Fix** Any showstoppers or operation impacting problems are immediately addressed by "Hot Fix" patches. 
- - **Solution Architects** Aviatrix solution architects can help you design your cloud network deployment to be simple to manage, scalable and secure. 
+ - **Solution Architects** Aviatrix solution architects can help you design your cloud network deployment to be simple to manage, scalable, and secure. 
 
 10. Flexible Consumption Model
---------------------------------
- - **Pay as You Consume** No contract negotiation, no lengthy PO process and no shelfware. Aviatrix provides a cloud consumption model with multi dimensional Metered AMI for instant consumption and need based scaling.
+----------------------------------------------
+ - **Pay as You Consume** No contract negotiation, no lengthy PO process, and no shelfware. Aviatrix provides a cloud consumption model with multi-dimensional Metered AMI for instant consumption and need-based scaling.
  - **Private Offers** Aviatrix provides a Private Offers AMI that has the same benefit as the Metered AMI but with customized pricing.  
- - **BYOL License** Aviatrix provides subscription based long term contracts for organizations that seek a predictable and budget based consumption model. 
+ - **BYOL License** Aviatrix provides subscription-based long-term contracts for organizations that seek a predictable and budget-based consumption model. 
 
 
 .. |aviatrix_dashboard| image:: aviatrix_operations_media/aviatrix_dashboard.png

--- a/StartUpGuides/google-aviatrix-cloud-controller-startup-guide.rst
+++ b/StartUpGuides/google-aviatrix-cloud-controller-startup-guide.rst
@@ -10,10 +10,10 @@ The Aviatrix cloud network solution consists of two components, the Controller a
 Gateway, both of which are GCloud instances. The gateway is launched from the Controller browser console.
 This guide helps you to launch the Controller instance in GCloud:
 
-* Prerequisites
-* Launching the Aviatrix Controller
-* Accessing the Aviatrix Controller
-* Onboarding Your GCP Account to your Aviatrix Controller
+* `Prerequisites <https://docs.aviatrix.com/StartUpGuides/google-aviatrix-cloud-controller-startup-guide.html#prerequisites>`_
+* `Launching the Aviatrix Controller <https://docs.aviatrix.com/StartUpGuides/google-aviatrix-cloud-controller-startup-guide.html#option-1-copy-aviatrix-controller-image-to-your-project>`_
+* `Accessing the Aviatrix Controller <https://docs.aviatrix.com/StartUpGuides/google-aviatrix-cloud-controller-startup-guide.html#accessing-the-aviatrix-controller>`_
+* `Onboarding Your GCP Account to your Aviatrix Controller <https://docs.aviatrix.com/StartUpGuides/google-aviatrix-cloud-controller-startup-guide.html#onboarding>`_
 
 Note that a GCloud project corresponds to an Aviatrix cloud account
 or an AWS (IAM) account with its own credentials. A network in a GCloud
@@ -169,10 +169,10 @@ Follow the initial setup process to set up an admin email address and password a
 .. Note:: Upgrade from 5.3 to 5.4 is not supported Controller needs to be migrated. Look at the GCP controller migration section in the below link.
 https://docs.aviatrix.com/HowTos/controller_migration.html
 
-Onboarding
-================
+Onboarding Your GCP Account to Your Aviatrix Controller
+===============================================
 
-If no GCloud account has been setup, you will be guided through the
+If no GCloud account has been set up, you will be guided through the
 onboarding process. It takes only a few steps. Once that is done, follow
 the quick tour guide to start launching gateways.
 


### PR DESCRIPTION
Formatting fixes, and replacing AWS-centric terms like EC2 with general terms + CSP-specific synonyms like "virtual machine (EC2/Azure VM/etc.) where appropriate.