### PR TITLE
Fix connection definition table in Meraki documentation

### DIFF
--- a/HowTos/site2cloud_meraki.rst
+++ b/HowTos/site2cloud_meraki.rst
@@ -32,7 +32,7 @@ Adding a Site2Cloud Tunnel in Aviatrix Controller
 3. Click on **+ Add New** near the top of the Site2Cloud tab.
 4. Under Add a New Connection, enter the following:
 
-    +-------------------------------+------------------------------------------+
+  +-------------------------------+------------------------------------------+
   | Field                         | Expected Value                           |
   +===============================+==========================================+
   | VPC ID / VNet Name            | Select the VPC/VNet where this tunnel    |


### PR DESCRIPTION
There were two characters missing keeping the table from rendering correctly